### PR TITLE
v2: secure-by-default loader + discoverability, quality & project-health overhaul

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Report a problem with the dotenv package
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: A minimal .env snippet and Go code that reproduces the issue.
+      render: go
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      placeholder: v1.2.0
+    validations:
+      required: true
+  - type: input
+    id: goversion
+    attributes:
+      label: Go version (go version)
+      placeholder: go1.23.0 linux/amd64
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
     id: version
     attributes:
       label: Package version
-      placeholder: v1.2.0
+      placeholder: v2.0.0
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/jaavier/dotenv/discussions
+    about: Ask questions and discuss usage with the community.
+  - name: Security vulnerability
+    url: https://github.com/jaavier/dotenv/security/advisories/new
+    about: Privately report a security issue (do not open a public issue).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an idea for the dotenv package
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem would this feature solve? Why do you need it?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the API or behavior you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Thanks for contributing! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation only
+
+## Checklist
+
+- [ ] `go test ./...` passes
+- [ ] `gofmt -l .` reports no files
+- [ ] `golangci-lint run` is clean
+- [ ] Added/updated tests for the change
+- [ ] Updated documentation (README / doc comments) if needed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (go ${{ matrix.go }} / ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ["1.17", "1.20", "1.22", "1.23"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+  race:
+    name: race + coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+      - run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-ed:"; echo "$unformatted"; exit 1
+          fi
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.5.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-and-quality
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+version: "2"
+
+linters:
+  enable:
+    - misspell
+    - unconvert
+    - revive
+  settings:
+    misspell:
+      locale: US
+  exclusions:
+    rules:
+      # Setting/unsetting env vars and cleanup in tests/examples is best-effort.
+      - path: (_test\.go|example/program\.go)
+        linters:
+          - errcheck
+      # QF1001 (apply De Morgan's law) is a style quickfix, not a correctness issue.
+      - text: "QF1001"
+        linters:
+          - staticcheck
+
+formatters:
+  enable:
+    - gofmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - Unreleased
+
+This is a major release. The module path is now
+`github.com/jaavier/dotenv/v2` — update your imports accordingly:
+
+```go
+import "github.com/jaavier/dotenv/v2"
+```
 
 ### Added
 
@@ -22,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Behavior change (security):** `Load` and `LoadWithOptions(nil, ...)` no
+- **BREAKING (module path):** the module is now `github.com/jaavier/dotenv/v2`.
+- **BREAKING (security default):** `Load` and `LoadWithOptions(nil, ...)` no
   longer override variables that already exist in the process environment.
   Following the 12-factor methodology, the real environment is authoritative
   and a `.env` file only fills in what is missing. Use `Overload` (or
@@ -48,6 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial `.env` loader with `Load` / `LoadWithOptions`.
 
-[Unreleased]: https://github.com/jaavier/dotenv/compare/v1.1.0...HEAD
+[2.0.0]: https://github.com/jaavier/dotenv/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/jaavier/dotenv/releases/tag/v1.1.0
 [1.0.0]: https://github.com/jaavier/dotenv/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `Parse(io.Reader)` and `ParseBytes([]byte)` — pure parsing into a
+  `map[string]string` with **no** side effects on the process environment.
+- `Overload(...)` — explicit loader that lets file values override existing
+  environment variables.
+- `Options.MaxFileSize` and the `DefaultMaxFileSize` constant to configure the
+  size limit.
+- `ErrFileTooLarge` sentinel error (testable via `errors.Is`).
+- Support for multi-line quoted values (e.g. PEM keys), the optional leading
+  `export` token, UTF-8 BOM, and CRLF line endings.
+- Testable examples (rendered on pkg.go.dev) and benchmarks.
+
+### Changed
+
+- **Behavior change (security):** `Load` and `LoadWithOptions(nil, ...)` no
+  longer override variables that already exist in the process environment.
+  Following the 12-factor methodology, the real environment is authoritative
+  and a `.env` file only fills in what is missing. Use `Overload` (or
+  `Options{Override: true}`) for the previous override behavior.
+- Files are now applied **atomically**: the whole file is parsed before any
+  variable is set, so a malformed file never leaves a half-applied environment.
+- Correct POSIX-ish quoting: double quotes expand escapes (`\n \r \t \\ \"`),
+  single quotes are literal, and unquoted values support inline `# comments`.
+- The size limit is enforced on the bytes actually read (safe for pipes and
+  special files), and the 64 KB line cap from `bufio.Scanner` is gone.
+
+### Fixed
+
+- Single-quoted and unquoted values no longer have escape sequences expanded.
+- Trailing garbage after a closing quote is now rejected as `ErrInvalidFormat`.
+
+## [1.1.0] - Earlier release
+
+- Clean-architecture refactor and utility functions (`Get`, `GetOrDefault`,
+  `GetOrPanic`, `MustLoad`).
+
+## [1.0.0] - Initial release
+
+- Initial `.env` loader with `Load` / `LoadWithOptions`.
+
+[Unreleased]: https://github.com/jaavier/dotenv/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/jaavier/dotenv/releases/tag/v1.1.0
+[1.0.0]: https://github.com/jaavier/dotenv/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Contributor Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+
+Unacceptable behavior includes harassment, insulting or derogatory comments,
+and personal or political attacks.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers. All complaints will be reviewed and investigated
+promptly and fairly.
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for your interest in improving `dotenv`! This package aims to stay
+**small, dependency-free, and secure**, so contributions are evaluated with
+that philosophy in mind.
+
+## Getting started
+
+```bash
+git clone https://github.com/jaavier/dotenv
+cd dotenv
+make test      # run the test suite
+make race      # run with the race detector
+make cover     # coverage report
+make lint      # golangci-lint
+```
+
+If you don't have `make`, the equivalent commands are:
+
+```bash
+go test ./...
+go test -race ./...
+golangci-lint run ./...
+gofmt -l .     # should print nothing
+```
+
+## Guidelines
+
+- **Keep it minimal.** No third-party dependencies. The package should remain a
+  single, focused file.
+- **Tests first.** New behavior needs tests; bug fixes should come with a
+  regression test.
+- **Security by default.** Changes must not weaken the safe defaults (e.g. not
+  overriding existing environment variables).
+- **Formatting & linting.** `gofmt -l .` must be empty and `golangci-lint run`
+  must be clean before you open a PR.
+- **Document it.** Update doc comments and the README when behavior changes, and
+  add an entry to `CHANGELOG.md`.
+
+## Pull requests
+
+1. Fork and create a feature branch.
+2. Make your change with tests and docs.
+3. Ensure CI is green.
+4. Open a PR using the template and describe the motivation clearly.
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: test race cover bench lint fmt vet check
+
+# Run the test suite.
+test:
+	go test ./...
+
+# Run tests with the race detector.
+race:
+	go test -race ./...
+
+# Produce a coverage summary.
+cover:
+	go test -covermode=atomic -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
+
+# Run benchmarks.
+bench:
+	go test -bench=. -benchmem -run=^$$ ./...
+
+# Lint with golangci-lint.
+lint:
+	golangci-lint run ./...
+
+# Format all Go files in place.
+fmt:
+	gofmt -w .
+
+# go vet.
+vet:
+	go vet ./...
+
+# Everything CI runs.
+check: fmt vet test lint

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 > variables from `.env` files. A modern, actively maintained alternative to
 > [godotenv](https://github.com/joho/godotenv).
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/jaavier/dotenv.svg)](https://pkg.go.dev/github.com/jaavier/dotenv)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jaavier/dotenv)](https://goreportcard.com/report/github.com/jaavier/dotenv)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jaavier/dotenv/v2.svg)](https://pkg.go.dev/github.com/jaavier/dotenv/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jaavier/dotenv/v2)](https://goreportcard.com/report/github.com/jaavier/dotenv/v2)
 [![CI](https://github.com/jaavier/dotenv/actions/workflows/ci.yml/badge.svg)](https://github.com/jaavier/dotenv/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/jaavier/dotenv/branch/main/graph/badge.svg)](https://codecov.io/gh/jaavier/dotenv)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/jaavier/dotenv)](go.mod)
@@ -69,7 +69,7 @@ Run it yourself: `make bench` (or `go test -bench=. -benchmem ./...`).
 ### Installation
 
 ```bash
-go get github.com/jaavier/dotenv
+go get github.com/jaavier/dotenv/v2
 ```
 
 ### Quick Start
@@ -91,7 +91,7 @@ import (
     "log"
     "os"
     
-    "github.com/jaavier/dotenv"
+    "github.com/jaavier/dotenv/v2"
 )
 
 func main() {
@@ -273,7 +273,7 @@ const DefaultMaxFileSize = 1 << 20 // 1 MiB
 ### FAQ
 
 **How do I load a `.env` file in Go?**
-`go get github.com/jaavier/dotenv`, then call `dotenv.Load()` at startup and read
+`go get github.com/jaavier/dotenv/v2`, then call `dotenv.Load()` at startup and read
 values with `os.Getenv` (or `dotenv.Get` / `GetOrDefault`).
 
 **Does it override my existing environment variables?**
@@ -292,6 +292,13 @@ calling `Parse` if you need it.
 **Can I parse a string or stream without touching the environment?**
 Yes: `dotenv.Parse(io.Reader)` and `dotenv.ParseBytes([]byte)` return a map and
 never mutate global state.
+
+**How do I upgrade from v1?**
+Update the import path to `github.com/jaavier/dotenv/v2` and run
+`go get github.com/jaavier/dotenv/v2`. The package name and all function
+signatures are unchanged; the only behavior change is that `Load` no longer
+overrides existing environment variables by default (use `Overload` for the old
+behavior).
 
 **Which Go versions are supported?**
 Go 1.17 and newer (tested on Linux, macOS and Windows in CI).
@@ -317,7 +324,7 @@ If this package is useful to you, please consider giving it a ⭐ on
 ### Instalación
 
 ```bash
-go get github.com/jaavier/dotenv
+go get github.com/jaavier/dotenv/v2
 ```
 
 ### Inicio Rápido
@@ -339,7 +346,7 @@ import (
     "log"
     "os"
     
-    "github.com/jaavier/dotenv"
+    "github.com/jaavier/dotenv/v2"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A minimalist, secure, and robust Go library for loading environment variables fr
 
 ### Features
 
-- **Minimalist**: Focus on loading environment variables safely - nothing more, nothing less
-- **Secure**: File size limits, path sanitization, and permission checks
-- **Robust**: Comprehensive error handling with specific error types
-- **Clean**: Professional code structure following clean architecture principles
-- **Flexible**: Support for multiple files and configuration options
-- **Safe**: Input validation and secure parsing
+- **Minimalist**: Zero dependencies (standard library only), single file. Loads environment variables safely - nothing more, nothing less
+- **Secure by default**: Following 12-factor, the real process environment always wins — a `.env` file never overrides existing variables unless you explicitly ask it to (`Overload`)
+- **Robust**: Comprehensive error handling with specific error types; files are applied atomically (a malformed file never leaves a half-applied environment)
+- **Correct parsing**: POSIX-ish quoting — double quotes expand escapes, single quotes are literal, unquoted values support inline `# comments`, optional `export` prefix, multi-line quoted values
+- **Side-effect free option**: `Parse`/`ParseBytes` return a `map[string]string` without ever touching the global environment — ideal for testing
+- **Hardened**: Configurable file-size limit to prevent memory exhaustion; no `bufio.Scanner` 64KB line cap
 
 ### Installation
 
@@ -46,7 +46,8 @@ import (
 )
 
 func main() {
-    // Load default .env file
+    // Load default .env file. Existing environment variables are NOT
+    // overridden; the file only fills in what is missing.
     if err := dotenv.Load(); err != nil {
         log.Printf("Warning: %v", err)
     }
@@ -57,6 +58,11 @@ func main() {
 }
 ```
 
+> **Secure default:** `Load` never overrides variables that already exist in
+> the process environment. This matches `godotenv`/12-factor: the runtime is the
+> source of truth and a stale or accidental `.env` cannot clobber injected
+> secrets. Use `Overload` when you explicitly want the file to win.
+
 ### Advanced Usage
 
 #### Load Multiple Files
@@ -66,12 +72,29 @@ func main() {
 err := dotenv.Load(".env.local", ".env")
 ```
 
+#### Override Existing Variables
+
+```go
+// Overload lets file values overwrite existing env vars (opt-in).
+err := dotenv.Overload(".env")
+```
+
+#### Parse Without Side Effects
+
+```go
+// Parse returns a map and never mutates the global environment.
+vars, err := dotenv.Parse(reader)        // any io.Reader
+vars, err = dotenv.ParseBytes(data)      // or raw bytes
+fmt.Println(vars["API_KEY"])
+```
+
 #### Custom Options
 
 ```go
 opts := &dotenv.Options{
-    Override: false,  // Don't override existing env vars
-    Required: true,   // File must exist
+    Override:    false,        // default: do not override existing env vars
+    Required:    true,         // file must exist
+    MaxFileSize: 64 * 1024,    // optional cap in bytes (0 => DefaultMaxFileSize)
 }
 
 err := dotenv.LoadWithOptions(opts, ".env.production")
@@ -100,21 +123,30 @@ dbHost := dotenv.GetOrPanic("DB_HOST")
 ### Supported Formats
 
 ```env
-# Comments are supported
+# Full-line comments are supported
 SIMPLE_KEY=value
 
-# Quoted values
-QUOTED_VALUE="value with spaces"
-SINGLE_QUOTED='single quotes also work'
+# Inline comments (unquoted values only; '#' must follow whitespace)
+PORT=8080            # the http port
+PASSWORD=p#ss        # '#' kept: not preceded by whitespace
 
-# Empty values
-EMPTY_VALUE=
+# Optional leading 'export' (so the file can also be `source`d by a shell)
+export API_KEY=secret
 
-# Special characters (escaped)
+# Double quotes: escape sequences (\n \r \t \\ \") are expanded
 MULTILINE="Line 1\nLine 2"
 WITH_TAB="Column1\tColumn2"
 
-# Trim spaces
+# Single quotes: fully literal, no escapes, no comment stripping
+LITERAL='value with \n kept as-is and a # too'
+
+# Multi-line quoted values (e.g. PEM keys)
+PRIVATE_KEY="-----BEGIN KEY-----
+line2
+-----END KEY-----"
+
+# Empty values, and surrounding whitespace is trimmed on unquoted values
+EMPTY_VALUE=
 TRIMMED_VALUE=  value with spaces trimmed  
 ```
 
@@ -133,6 +165,8 @@ if err := dotenv.Load(".env"); err != nil {
         // Invalid line format
     case errors.Is(err, dotenv.ErrEmptyKey):
         // Empty key found
+    case errors.Is(err, dotenv.ErrFileTooLarge):
+        // File exceeds the configured size limit
     default:
         // Other error
     }
@@ -141,20 +175,26 @@ if err := dotenv.Load(".env"); err != nil {
 
 ### Security Features
 
-- **File size limit**: Maximum 1MB to prevent memory exhaustion
-- **Path sanitization**: Prevents directory traversal attacks
-- **Permission checks**: Validates file permissions before reading
-- **Key validation**: Only allows valid environment variable names
-- **Safe parsing**: Handles malformed input gracefully
+- **No-clobber default**: `.env` never overrides existing process env vars (12-factor); overriding is opt-in via `Overload`
+- **Atomic apply**: each file is fully parsed before any variable is set, so a parse error never leaves a partially-applied environment
+- **Side-effect-free parsing**: `Parse`/`ParseBytes` never mutate the global environment
+- **Resource limits**: configurable file-size cap (default 1 MiB), enforced on the bytes actually read (safe for pipes/special files), with no 64KB line cap
+- **No code execution**: command substitution (`$(...)`) and shell evaluation are never performed
+- **Key validation**: only valid environment variable names (`[A-Za-z_][A-Za-z0-9_]*`) are accepted
 
 ### API Reference
 
 #### Functions
 
 **Loading Functions:**
-- `Load(filenames ...string) error` - Load one or more .env files
+- `Load(filenames ...string) error` - Load one or more .env files without overriding existing env vars
+- `Overload(filenames ...string) error` - Load files, letting them override existing env vars
 - `LoadWithOptions(opts *Options, filenames ...string) error` - Load with custom options
 - `MustLoad(filenames ...string)` - Load files or panic
+
+**Parsing (no side effects):**
+- `Parse(r io.Reader) (map[string]string, error)` - Parse into a map without touching the environment
+- `ParseBytes(data []byte) (map[string]string, error)` - Convenience wrapper for in-memory data
 
 **Getting Variables:**
 - `Get(key string) string` - Get environment variable value (alias for os.Getenv)
@@ -165,17 +205,21 @@ if err := dotenv.Load(".env"); err != nil {
 
 ```go
 type Options struct {
-    Override bool  // Override existing environment variables
-    Required bool  // File must exist (return error if not found)
+    Override    bool  // override existing environment variables (default false)
+    Required    bool  // file must exist (return error if not found)
+    MaxFileSize int64 // max bytes to read; <= 0 uses DefaultMaxFileSize
 }
+
+const DefaultMaxFileSize = 1 << 20 // 1 MiB
 ```
 
 #### Errors
 
 - `ErrFileNotFound` - File does not exist
-- `ErrInvalidFormat` - Invalid line format (missing =)
+- `ErrInvalidFormat` - Invalid line format (missing `=`, unterminated quote, or garbage after a quote)
 - `ErrEmptyKey` - Empty key name
 - `ErrPermissionDenied` - No permission to read file
+- `ErrFileTooLarge` - File exceeds the maximum size
 
 ---
 
@@ -183,12 +227,12 @@ type Options struct {
 
 ### Características
 
-- **Minimalista**: Enfocado en cargar variables de entorno de manera segura - nada más, nada menos
-- **Seguro**: Límites de tamaño de archivo, sanitización de rutas y verificación de permisos
-- **Robusto**: Manejo completo de errores con tipos de error específicos
-- **Limpio**: Estructura de código profesional siguiendo principios de arquitectura limpia
-- **Flexible**: Soporte para múltiples archivos y opciones de configuración
-- **Confiable**: Validación de entrada y análisis seguro
+- **Minimalista**: Cero dependencias (solo librería estándar), un único archivo. Carga variables de entorno de manera segura - nada más, nada menos
+- **Seguro por defecto**: Siguiendo 12-factor, el entorno real del proceso siempre gana — un archivo `.env` nunca sobrescribe variables existentes a menos que lo pidas explícitamente (`Overload`)
+- **Robusto**: Manejo completo de errores con tipos específicos; los archivos se aplican de forma atómica (un archivo malformado nunca deja el entorno aplicado a medias)
+- **Análisis correcto**: Comillas estilo POSIX — las comillas dobles expanden escapes, las simples son literales, los valores sin comillas soportan comentarios `# en línea`, prefijo `export` opcional y valores multilínea entre comillas
+- **Opción sin efectos secundarios**: `Parse`/`ParseBytes` devuelven un `map[string]string` sin tocar nunca el entorno global — ideal para tests
+- **Endurecido**: Límite de tamaño de archivo configurable para prevenir agotamiento de memoria; sin el límite de 64KB por línea de `bufio.Scanner`
 
 ### Instalación
 
@@ -219,7 +263,8 @@ import (
 )
 
 func main() {
-    // Cargar archivo .env por defecto
+    // Cargar archivo .env por defecto. Las variables de entorno existentes
+    // NO se sobrescriben; el archivo solo rellena lo que falta.
     if err := dotenv.Load(); err != nil {
         log.Printf("Advertencia: %v", err)
     }
@@ -230,6 +275,11 @@ func main() {
 }
 ```
 
+> **Default seguro:** `Load` nunca sobrescribe variables que ya existen en el
+> entorno del proceso. Esto coincide con `godotenv`/12-factor: el runtime es la
+> fuente de verdad y un `.env` accidental o desactualizado no puede pisar
+> secretos inyectados. Usa `Overload` cuando quieras que el archivo gane.
+
 ### Uso Avanzado
 
 #### Cargar Múltiples Archivos
@@ -239,12 +289,29 @@ func main() {
 err := dotenv.Load(".env.local", ".env")
 ```
 
+#### Sobrescribir Variables Existentes
+
+```go
+// Overload permite que los valores del archivo pisen las variables existentes.
+err := dotenv.Overload(".env")
+```
+
+#### Analizar Sin Efectos Secundarios
+
+```go
+// Parse devuelve un map y nunca muta el entorno global.
+vars, err := dotenv.Parse(reader)        // cualquier io.Reader
+vars, err = dotenv.ParseBytes(data)      // o bytes en crudo
+fmt.Println(vars["API_KEY"])
+```
+
 #### Opciones Personalizadas
 
 ```go
 opts := &dotenv.Options{
-    Override: false,  // No sobrescribir variables existentes
-    Required: true,   // El archivo debe existir
+    Override:    false,        // por defecto: no sobrescribir variables existentes
+    Required:    true,         // el archivo debe existir
+    MaxFileSize: 64 * 1024,    // límite opcional en bytes (0 => DefaultMaxFileSize)
 }
 
 err := dotenv.LoadWithOptions(opts, ".env.production")
@@ -273,21 +340,30 @@ dbHost := dotenv.GetOrPanic("DB_HOST")
 ### Formatos Soportados
 
 ```env
-# Los comentarios son soportados
+# Comentarios de línea completa soportados
 CLAVE_SIMPLE=valor
 
-# Valores con comillas
-VALOR_CON_COMILLAS="valor con espacios"
-COMILLAS_SIMPLES='las comillas simples también funcionan'
+# Comentarios en línea (solo valores sin comillas; '#' debe seguir a un espacio)
+PUERTO=8080            # el puerto http
+PASSWORD=p#ss          # '#' conservado: no va precedido de espacio
 
-# Valores vacíos
-VALOR_VACIO=
+# Prefijo 'export' opcional (para que el archivo también pueda `source`arse)
+export API_KEY=secreto
 
-# Caracteres especiales (escapados)
+# Comillas dobles: se expanden los escapes (\n \r \t \\ \")
 MULTILINEA="Línea 1\nLínea 2"
 CON_TAB="Columna1\tColumna2"
 
-# Eliminar espacios
+# Comillas simples: totalmente literal, sin escapes ni comentarios
+LITERAL='valor con \n tal cual y un # también'
+
+# Valores multilínea entre comillas (p. ej. claves PEM)
+PRIVATE_KEY="-----BEGIN KEY-----
+line2
+-----END KEY-----"
+
+# Valores vacíos; los espacios alrededor se recortan en valores sin comillas
+VALOR_VACIO=
 VALOR_LIMPIO=  valor con espacios eliminados  
 ```
 
@@ -306,6 +382,8 @@ if err := dotenv.Load(".env"); err != nil {
         // Formato de línea inválido
     case errors.Is(err, dotenv.ErrEmptyKey):
         // Se encontró una clave vacía
+    case errors.Is(err, dotenv.ErrFileTooLarge):
+        // El archivo excede el límite de tamaño configurado
     default:
         // Otro error
     }
@@ -314,20 +392,26 @@ if err := dotenv.Load(".env"); err != nil {
 
 ### Características de Seguridad
 
-- **Límite de tamaño**: Máximo 1MB para prevenir agotamiento de memoria
-- **Sanitización de rutas**: Previene ataques de traversal de directorios
-- **Verificación de permisos**: Valida permisos antes de leer
-- **Validación de claves**: Solo permite nombres válidos de variables
-- **Análisis seguro**: Maneja entradas malformadas de manera elegante
+- **Default sin sobrescritura**: el `.env` nunca pisa variables existentes del proceso (12-factor); sobrescribir es explícito con `Overload`
+- **Aplicación atómica**: cada archivo se analiza por completo antes de fijar ninguna variable, así un error de formato nunca deja el entorno a medias
+- **Análisis sin efectos secundarios**: `Parse`/`ParseBytes` nunca mutan el entorno global
+- **Límites de recursos**: tope de tamaño de archivo configurable (1 MiB por defecto), aplicado sobre los bytes realmente leídos (seguro para pipes/archivos especiales), sin límite de 64KB por línea
+- **Sin ejecución de código**: nunca se realiza sustitución de comandos (`$(...)`) ni evaluación de shell
+- **Validación de claves**: solo se aceptan nombres válidos de variables (`[A-Za-z_][A-Za-z0-9_]*`)
 
 ### Referencia API
 
 #### Funciones
 
 **Funciones de Carga:**
-- `Load(filenames ...string) error` - Cargar uno o más archivos .env
+- `Load(filenames ...string) error` - Cargar uno o más archivos .env sin sobrescribir variables existentes
+- `Overload(filenames ...string) error` - Cargar archivos dejando que sobrescriban las variables existentes
 - `LoadWithOptions(opts *Options, filenames ...string) error` - Cargar con opciones personalizadas
 - `MustLoad(filenames ...string)` - Cargar archivos o hacer panic
+
+**Análisis (sin efectos secundarios):**
+- `Parse(r io.Reader) (map[string]string, error)` - Analizar a un map sin tocar el entorno
+- `ParseBytes(data []byte) (map[string]string, error)` - Atajo para datos en memoria
 
 **Funciones para Obtener Variables:**
 - `Get(key string) string` - Obtener valor de variable de entorno (alias de os.Getenv)
@@ -338,17 +422,21 @@ if err := dotenv.Load(".env"); err != nil {
 
 ```go
 type Options struct {
-    Override bool  // Sobrescribir variables de entorno existentes
-    Required bool  // El archivo debe existir (retorna error si no)
+    Override    bool  // sobrescribir variables existentes (por defecto false)
+    Required    bool  // el archivo debe existir (retorna error si no)
+    MaxFileSize int64 // máximo de bytes a leer; <= 0 usa DefaultMaxFileSize
 }
+
+const DefaultMaxFileSize = 1 << 20 // 1 MiB
 ```
 
 #### Errores
 
 - `ErrFileNotFound` - El archivo no existe
-- `ErrInvalidFormat` - Formato de línea inválido (falta =)
+- `ErrInvalidFormat` - Formato inválido (falta `=`, comilla sin cerrar o basura tras una comilla)
 - `ErrEmptyKey` - Nombre de clave vacío
 - `ErrPermissionDenied` - Sin permisos para leer el archivo
+- `ErrFileTooLarge` - El archivo excede el tamaño máximo
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-# dotenv
+# dotenv — lightweight & secure `.env` loader for Go
 
-A minimalist, secure, and robust Go library for loading environment variables from `.env` files. Built with clean architecture principles, focusing on doing one thing with excellence.
+> A tiny, **zero-dependency**, security-first Go library to load environment
+> variables from `.env` files. A modern, actively maintained alternative to
+> [godotenv](https://github.com/joho/godotenv).
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/jaavier/dotenv.svg)](https://pkg.go.dev/github.com/jaavier/dotenv)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jaavier/dotenv)](https://goreportcard.com/report/github.com/jaavier/dotenv)
+[![CI](https://github.com/jaavier/dotenv/actions/workflows/ci.yml/badge.svg)](https://github.com/jaavier/dotenv/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/jaavier/dotenv/branch/main/graph/badge.svg)](https://codecov.io/gh/jaavier/dotenv)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/jaavier/dotenv)](go.mod)
+[![Release](https://img.shields.io/github/v/release/jaavier/dotenv?sort=semver)](https://github.com/jaavier/dotenv/releases)
+[![Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)](go.mod)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+Keywords: golang dotenv, load `.env` file in Go, environment variables, 12-factor
+config, godotenv alternative, secure env loader.
 
 [Español](#español) | [English](#english)
 
@@ -16,6 +30,41 @@ A minimalist, secure, and robust Go library for loading environment variables fr
 - **Correct parsing**: POSIX-ish quoting — double quotes expand escapes, single quotes are literal, unquoted values support inline `# comments`, optional `export` prefix, multi-line quoted values
 - **Side-effect free option**: `Parse`/`ParseBytes` return a `map[string]string` without ever touching the global environment — ideal for testing
 - **Hardened**: Configurable file-size limit to prevent memory exhaustion; no `bufio.Scanner` 64KB line cap
+
+### Why dotenv? (vs godotenv)
+
+[godotenv](https://github.com/joho/godotenv) is great and battle-tested, but it
+has been declared **feature-complete** and no longer accepts new functionality.
+`dotenv` is a small, modern, actively-maintained alternative with safer
+defaults.
+
+| | `jaavier/dotenv` | `joho/godotenv` |
+| --- | --- | --- |
+| Dependencies | **0** (stdlib only) | 0 |
+| Overrides existing env by default | **No** (safe; `Overload` to opt in) | No (`Load`) / Yes (`Overload`) |
+| Atomic apply (all-or-nothing per file) | **Yes** | No |
+| Side-effect-free `Parse` / `ParseBytes` | **Yes** | `Read` returns a map |
+| Inline `# comments` (unquoted) | **Yes** | Yes |
+| Single-quote literal vs double-quote escapes | **Yes** | Yes |
+| Multi-line quoted values (PEM keys) | **Yes** | Yes |
+| Configurable max file size (DoS guard) | **Yes** | No |
+| Long lines > 64 KB | **Yes** | Limited by Scanner |
+| Variable expansion `${VAR}` | No (by design — no injection surface) | Yes |
+| Actively maintained | **Yes** | Feature-complete |
+
+> `dotenv` deliberately omits `${VAR}` interpolation to keep the attack surface
+> minimal. If you need interpolation, expand values yourself after `Parse`.
+
+### Performance
+
+Parsing a representative `.env` (15 keys, comments, quotes, escapes) on a
+commodity CPU:
+
+```
+BenchmarkParse-4         217534    ~4.6 µs/op    77 MB/s    3416 B/op    24 allocs/op
+```
+
+Run it yourself: `make bench` (or `go test -bench=. -benchmem ./...`).
 
 ### Installation
 
@@ -220,6 +269,37 @@ const DefaultMaxFileSize = 1 << 20 // 1 MiB
 - `ErrEmptyKey` - Empty key name
 - `ErrPermissionDenied` - No permission to read file
 - `ErrFileTooLarge` - File exceeds the maximum size
+
+### FAQ
+
+**How do I load a `.env` file in Go?**
+`go get github.com/jaavier/dotenv`, then call `dotenv.Load()` at startup and read
+values with `os.Getenv` (or `dotenv.Get` / `GetOrDefault`).
+
+**Does it override my existing environment variables?**
+No. `Load` only fills in variables that are not already set — the real
+environment always wins. Use `dotenv.Overload(...)` if you want the file to win.
+
+**Is it a drop-in replacement for godotenv?**
+The API differs, but migration is trivial: `godotenv.Load` → `dotenv.Load`,
+`godotenv.Overload` → `dotenv.Overload`, `godotenv.Read` → `dotenv.Parse`.
+The main intentional difference is that `${VAR}` interpolation is not performed.
+
+**Does it support variable expansion like `${OTHER}`?**
+No, by design — this avoids an injection surface. Expand values yourself after
+calling `Parse` if you need it.
+
+**Can I parse a string or stream without touching the environment?**
+Yes: `dotenv.Parse(io.Reader)` and `dotenv.ParseBytes([]byte)` return a map and
+never mutate global state.
+
+**Which Go versions are supported?**
+Go 1.17 and newer (tested on Linux, macOS and Windows in CI).
+
+---
+
+If this package is useful to you, please consider giving it a ⭐ on
+[GitHub](https://github.com/jaavier/dotenv) — it genuinely helps others discover it.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ The latest released minor version receives security fixes.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.x     | ✅        |
+| 2.x     | ✅        |
+| 1.x     | ⚠️ best-effort |
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+The latest released minor version receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | ✅        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, report privately via GitHub's
+[security advisories](https://github.com/jaavier/dotenv/security/advisories/new).
+You can expect an initial response within a few days. Once a fix is available,
+a patched release will be published and the advisory disclosed.
+
+## Security design notes
+
+This package is built to be safe by default:
+
+- **No override of real environment variables.** `Load` never overwrites
+  variables already present in the process environment; overriding is the
+  explicit, opt-in `Overload`. This prevents a stale or accidentally-present
+  `.env` from clobbering securely-injected configuration (12-factor).
+- **No code execution.** Command substitution (`$(...)`) and shell evaluation
+  are never performed.
+- **Resource limits.** A configurable file-size cap (default 1 MiB) is enforced
+  on the bytes actually read, protecting against memory-exhaustion from large
+  or special files.
+- **Atomic application.** A file is fully parsed before any variable is set, so
+  malformed input never leaves a partially-applied environment.
+- **Side-effect-free parsing.** `Parse` / `ParseBytes` never mutate global
+  state, making it safe to inspect untrusted input.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,50 @@
+package dotenv_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jaavier/dotenv"
+)
+
+// sampleEnv is a representative .env payload exercising comments, quotes,
+// escapes and inline comments.
+const sampleEnv = `# Application configuration
+APP_ENV=production
+APP_DEBUG=false
+APP_PORT=8080            # http port
+
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=app
+DB_PASSWORD="s3cr3t#pass"
+DB_DSN="host=localhost port=5432 dbname=app sslmode=disable"
+
+API_KEY=AKIAIOSFODNN7EXAMPLE
+API_URL=https://api.example.com/v1
+
+MESSAGE="Hello,\tWorld!\n"
+LITERAL='no $expansion or \n here'
+`
+
+func BenchmarkParse(b *testing.B) {
+	data := []byte(sampleEnv)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := dotenv.ParseBytes(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseReader(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := dotenv.Parse(strings.NewReader(sampleEnv)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jaavier/dotenv"
+	"github.com/jaavier/dotenv/v2"
 )
 
 // sampleEnv is a representative .env payload exercising comments, quotes,

--- a/dotenv.go
+++ b/dotenv.go
@@ -1,9 +1,9 @@
-// Package dotenv provides a minimalist, secure, and robust solution for loading
-// environment variables from .env files.
+// Package dotenv is a lightweight, dependency-free, secure loader for .env
+// files in Go — a modern, actively maintained alternative to godotenv.
 //
 // The package focuses on doing one thing with excellence: safely loading
-// environment variables from files. It is dependency-free (standard library
-// only), fits in a single file, and is secure by default.
+// environment variables from files. It uses only the standard library, fits in
+// a single file, and is secure by default.
 //
 // # Secure by default
 //
@@ -195,7 +195,7 @@ func loadFile(filename string, opts *Options) (map[string]string, error) {
 		}
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	return parseReader(file, maxSize)
 }

--- a/dotenv.go
+++ b/dotenv.go
@@ -1,60 +1,105 @@
 // Package dotenv provides a minimalist, secure, and robust solution for loading
 // environment variables from .env files.
 //
-// The package focuses on doing one thing with excellence: safely loading environment
-// variables from files. It provides comprehensive error handling, security features
-// like file size limits and path sanitization, and flexible configuration options.
+// The package focuses on doing one thing with excellence: safely loading
+// environment variables from files. It is dependency-free (standard library
+// only), fits in a single file, and is secure by default.
+//
+// # Secure by default
+//
+// Following the 12-factor methodology, the process environment is always
+// authoritative: Load does NOT override variables that already exist in the
+// environment. A .env file only fills in the gaps. If you explicitly want the
+// file to win, use Overload (or Options.Override).
 //
 // Basic usage:
 //
 //	import "github.com/jaavier/dotenv"
 //
 //	func main() {
-//	    // Load default .env file
+//	    // Load default .env file without overriding existing env vars.
 //	    if err := dotenv.Load(); err != nil {
 //	        log.Fatal(err)
 //	    }
 //	}
 //
+// Parsing without side effects:
+//
+//	vars, err := dotenv.Parse(reader) // returns a map, never touches os.Environ
+//
 // For more advanced usage, see the README documentation.
 package dotenv
 
 import (
-	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+// Sentinel errors returned by the package. Use errors.Is to test for them.
 var (
-	ErrFileNotFound    = errors.New("dotenv: file not found")
-	ErrInvalidFormat   = errors.New("dotenv: invalid format")
-	ErrEmptyKey        = errors.New("dotenv: empty key")
+	ErrFileNotFound     = errors.New("dotenv: file not found")
+	ErrInvalidFormat    = errors.New("dotenv: invalid format")
+	ErrEmptyKey         = errors.New("dotenv: empty key")
 	ErrPermissionDenied = errors.New("dotenv: permission denied")
+	ErrFileTooLarge     = errors.New("dotenv: file exceeds maximum size")
 )
 
 const (
 	defaultFile = ".env"
-	maxFileSize = 1 << 20
+
+	// DefaultMaxFileSize is the maximum size, in bytes, of a .env file that
+	// will be read when Options.MaxFileSize is not set. It guards against
+	// resource-exhaustion from pathologically large files.
+	DefaultMaxFileSize = 1 << 20 // 1 MiB
 )
 
+// utf8BOM is stripped from the start of a file if present.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// Options configures how environment files are loaded.
+//
+// The zero value is the recommended, secure configuration: it does not
+// override existing environment variables, treats missing files as
+// non-fatal, and uses DefaultMaxFileSize.
 type Options struct {
+	// Override, when true, lets values from the file overwrite variables that
+	// already exist in the process environment. The default (false) is the
+	// secure choice: the real environment always wins.
 	Override bool
+
+	// Required, when true, causes loading to fail if a file does not exist.
 	Required bool
+
+	// MaxFileSize is the maximum size, in bytes, of a file to read. Values
+	// <= 0 fall back to DefaultMaxFileSize.
+	MaxFileSize int64
 }
 
+// Load reads one or more .env files (default ".env") and sets the contained
+// variables in the process environment WITHOUT overriding variables that are
+// already set. Missing files are ignored. See Overload to override.
 func Load(filenames ...string) error {
 	return LoadWithOptions(nil, filenames...)
 }
 
+// Overload is like Load but lets file values override variables that already
+// exist in the environment. Use it only when the file is the source of truth.
+func Overload(filenames ...string) error {
+	return LoadWithOptions(&Options{Override: true}, filenames...)
+}
+
+// LoadWithOptions reads one or more .env files using the supplied Options.
+// A nil opts means the secure zero-value configuration. Each file is parsed
+// in full before any variable is applied, so a malformed file never leaves a
+// partially-applied environment.
 func LoadWithOptions(opts *Options, filenames ...string) error {
 	if opts == nil {
-		opts = &Options{
-			Override: true,
-			Required: false,
-		}
+		opts = &Options{}
 	}
 
 	if len(filenames) == 0 {
@@ -62,157 +107,325 @@ func LoadWithOptions(opts *Options, filenames ...string) error {
 	}
 
 	for _, filename := range filenames {
-		if err := loadFile(filename, opts); err != nil {
+		vars, err := loadFile(filename, opts)
+		if err != nil {
 			if opts.Required || !errors.Is(err, ErrFileNotFound) {
-				return fmt.Errorf("failed to load %s: %w", filename, err)
+				return fmt.Errorf("dotenv: failed to load %s: %w", filename, err)
 			}
+			continue
+		}
+		if err := applyVars(vars, opts.Override); err != nil {
+			return fmt.Errorf("dotenv: failed to apply %s: %w", filename, err)
 		}
 	}
 
 	return nil
 }
 
-func loadFile(filename string, opts *Options) error {
+// MustLoad behaves like Load but panics on error. Use it only at program
+// startup for configuration the application cannot run without.
+func MustLoad(filenames ...string) {
+	if err := Load(filenames...); err != nil {
+		panic(err)
+	}
+}
+
+// Parse reads key/value pairs from r and returns them as a map. It performs
+// no I/O beyond reading r and never mutates the process environment, which
+// makes it ideal for testing and for inspecting values before applying them.
+// Reads are capped at DefaultMaxFileSize.
+func Parse(r io.Reader) (map[string]string, error) {
+	return parseReader(r, DefaultMaxFileSize)
+}
+
+// ParseBytes is a convenience wrapper around Parse for in-memory data.
+func ParseBytes(data []byte) (map[string]string, error) {
+	return parseReader(bytes.NewReader(data), DefaultMaxFileSize)
+}
+
+// applyVars writes vars to the process environment. When override is false a
+// variable is only set if it is not already present (an existing empty value
+// still counts as present and is preserved).
+func applyVars(vars map[string]string, override bool) error {
+	for k, v := range vars {
+		if !override {
+			if _, ok := os.LookupEnv(k); ok {
+				continue
+			}
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %w", k, err)
+		}
+	}
+	return nil
+}
+
+// loadFile validates and reads a single file into a map of key/value pairs.
+func loadFile(filename string, opts *Options) (map[string]string, error) {
 	filename = filepath.Clean(filename)
 
 	info, err := os.Stat(filename)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return ErrFileNotFound
+		switch {
+		case os.IsNotExist(err):
+			return nil, ErrFileNotFound
+		case os.IsPermission(err):
+			return nil, ErrPermissionDenied
+		default:
+			return nil, err
 		}
-		if os.IsPermission(err) {
-			return ErrPermissionDenied
-		}
-		return err
-	}
-
-	if info.Size() > maxFileSize {
-		return fmt.Errorf("file size exceeds maximum allowed size of %d bytes", maxFileSize)
 	}
 
 	if info.IsDir() {
-		return fmt.Errorf("expected file, got directory: %s", filename)
+		return nil, fmt.Errorf("expected file, got directory: %s", filename)
+	}
+
+	maxSize := opts.MaxFileSize
+	if maxSize <= 0 {
+		maxSize = DefaultMaxFileSize
+	}
+	if info.Size() > maxSize {
+		return nil, ErrFileTooLarge
 	}
 
 	file, err := os.Open(filename)
 	if err != nil {
 		if os.IsPermission(err) {
-			return ErrPermissionDenied
+			return nil, ErrPermissionDenied
 		}
-		return err
+		return nil, err
 	}
 	defer file.Close()
 
-	return parse(file, opts)
+	return parseReader(file, maxSize)
 }
 
-func parse(file *os.File, opts *Options) error {
-	scanner := bufio.NewScanner(file)
-	lineNum := 0
+// parseReader reads at most maxSize bytes from r and parses them. The limit is
+// enforced on the actual bytes read (not just a reported size), so it is safe
+// for pipes, sockets and special files where Stat lies about the size.
+func parseReader(r io.Reader, maxSize int64) (map[string]string, error) {
+	if maxSize <= 0 {
+		maxSize = DefaultMaxFileSize
+	}
 
-	for scanner.Scan() {
-		lineNum++
-		line := strings.TrimSpace(scanner.Text())
+	data, err := io.ReadAll(io.LimitReader(r, maxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+	if int64(len(data)) > maxSize {
+		return nil, ErrFileTooLarge
+	}
 
-		if len(line) == 0 || strings.HasPrefix(line, "#") {
+	data = bytes.TrimPrefix(data, utf8BOM)
+	lines := strings.Split(string(data), "\n")
+	out := make(map[string]string)
+
+	for i := 0; i < len(lines); i++ {
+		raw := strings.TrimRight(lines[i], "\r")
+		trimmed := strings.TrimSpace(raw)
+
+		if len(trimmed) == 0 || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
 
-		key, value, err := parseLine(line)
-		if err != nil {
-			return fmt.Errorf("line %d: %w", lineNum, err)
-		}
-
-		if len(key) > 0 {
-			if opts.Override || os.Getenv(key) == "" {
-				if err := os.Setenv(key, value); err != nil {
-					return fmt.Errorf("failed to set environment variable %s: %w", key, err)
-				}
+		// A quoted value may span multiple physical lines (e.g. a PEM key).
+		// Accumulate following lines until the quote is closed. Errors are
+		// reported against the line where the assignment begins.
+		start := i
+		logical := raw
+		for needsMoreLines(logical) {
+			i++
+			if i >= len(lines) {
+				return nil, fmt.Errorf("line %d: %w", start+1, ErrInvalidFormat)
 			}
+			logical += "\n" + strings.TrimRight(lines[i], "\r")
+		}
+
+		key, value, err := parseLine(logical)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", start+1, err)
+		}
+		if len(key) > 0 {
+			out[key] = value
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading file: %w", err)
-	}
-
-	return nil
+	return out, nil
 }
 
+// needsMoreLines reports whether logical opens a quoted value that has not yet
+// been closed, meaning more physical lines must be appended.
+func needsMoreLines(logical string) bool {
+	line := strings.TrimSpace(logical)
+	if rest, ok := cutExport(line); ok {
+		line = rest
+	}
+
+	eq := strings.IndexByte(line, '=')
+	if eq < 0 {
+		return false
+	}
+
+	v := strings.TrimLeft(line[eq+1:], " \t")
+	if len(v) == 0 {
+		return false
+	}
+
+	q := v[0]
+	if q != '"' && q != '\'' {
+		return false
+	}
+	return indexClosingQuote(v[1:], q) < 0
+}
+
+// parseLine parses a single logical line into a key/value pair. An empty or
+// comment-only line yields ("", "", nil). The leading "export " token, if
+// present, is ignored.
 func parseLine(line string) (string, string, error) {
+	line = strings.TrimSpace(line)
 	if len(line) == 0 {
 		return "", "", nil
 	}
 
-	equalIndex := strings.Index(line, "=")
-	if equalIndex == -1 {
+	if rest, ok := cutExport(line); ok {
+		line = rest
+	}
+
+	eq := strings.IndexByte(line, '=')
+	if eq == -1 {
 		return "", "", ErrInvalidFormat
 	}
 
-	key := strings.TrimSpace(line[:equalIndex])
+	key := strings.TrimSpace(line[:eq])
 	if len(key) == 0 {
 		return "", "", ErrEmptyKey
 	}
-
 	if !isValidKey(key) {
 		return "", "", fmt.Errorf("invalid key format: %s", key)
 	}
 
-	value := ""
-	if equalIndex < len(line)-1 {
-		value = line[equalIndex+1:]
-		value = processValue(value)
+	value, err := parseValue(line[eq+1:])
+	if err != nil {
+		return "", "", err
 	}
 
 	return key, value, nil
 }
 
-func processValue(value string) string {
-	value = strings.TrimSpace(value)
-
-	if len(value) >= 2 {
-		first, last := value[0], value[len(value)-1]
-		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
-			value = value[1 : len(value)-1]
-		}
+// parseValue interprets the raw right-hand side of an assignment following
+// POSIX-ish conventions:
+//   - double-quoted values expand escape sequences (\n \r \t \\ \");
+//   - single-quoted values are taken literally (no escapes, no comments);
+//   - unquoted values are trimmed and have inline "# comments" removed.
+func parseValue(raw string) (string, error) {
+	v := strings.TrimLeft(raw, " \t")
+	if len(v) == 0 {
+		return "", nil
 	}
 
-	value = expandEscapes(value)
-
-	return value
+	switch v[0] {
+	case '"':
+		idx := indexClosingQuote(v[1:], '"')
+		if idx < 0 || !validTrailer(v[2+idx:]) {
+			return "", ErrInvalidFormat // unterminated quote or trailing garbage
+		}
+		return expandEscapes(v[1 : 1+idx]), nil
+	case '\'':
+		idx := indexClosingQuote(v[1:], '\'')
+		if idx < 0 || !validTrailer(v[2+idx:]) {
+			return "", ErrInvalidFormat // unterminated quote or trailing garbage
+		}
+		return v[1 : 1+idx], nil
+	default:
+		return stripInlineComment(v), nil
+	}
 }
 
+// validTrailer reports whether the text following a closing quote is allowed:
+// only optional whitespace and an optional inline "# comment".
+func validTrailer(s string) bool {
+	s = strings.TrimLeft(s, " \t")
+	return len(s) == 0 || s[0] == '#'
+}
+
+// indexClosingQuote returns the index of the closing quote in s, or -1 if it
+// is not found. For double quotes a backslash escapes the next character;
+// single quotes are literal and the first quote closes.
+func indexClosingQuote(s string, quote byte) int {
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		c := s[i]
+		if quote == '"' && c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == quote {
+			return i
+		}
+	}
+	return -1
+}
+
+// stripInlineComment removes a trailing "# comment" from an unquoted value.
+// The '#' is only treated as a comment when it starts the value or is preceded
+// by whitespace, so values like "pa#ss" are preserved. Trailing whitespace is
+// trimmed.
+func stripInlineComment(v string) string {
+	for i := 0; i < len(v); i++ {
+		if v[i] == '#' && (i == 0 || v[i-1] == ' ' || v[i-1] == '\t') {
+			v = v[:i]
+			break
+		}
+	}
+	return strings.TrimRight(v, " \t")
+}
+
+// cutExport strips an optional leading "export " (or "export\t") token,
+// allowing files that can also be sourced by a shell.
+func cutExport(line string) (string, bool) {
+	const kw = "export"
+	if strings.HasPrefix(line, kw) && len(line) > len(kw) &&
+		(line[len(kw)] == ' ' || line[len(kw)] == '\t') {
+		return strings.TrimLeft(line[len(kw):], " \t"), true
+	}
+	return line, false
+}
+
+// expandEscapes interprets the escape sequences allowed inside double quotes.
 func expandEscapes(value string) string {
+	if !strings.ContainsRune(value, '\\') {
+		return value
+	}
 	replacer := strings.NewReplacer(
 		`\n`, "\n",
 		`\r`, "\r",
 		`\t`, "\t",
-		`\\`, "\\",
+		`\"`, `"`,
+		`\\`, `\`,
 	)
 	return replacer.Replace(value)
 }
 
+// isValidKey reports whether key matches [A-Za-z_][A-Za-z0-9_]*.
 func isValidKey(key string) bool {
 	if len(key) == 0 {
 		return false
 	}
 
 	for i, ch := range key {
-		if !((ch >= 'A' && ch <= 'Z') || 
-			(ch >= 'a' && ch <= 'z') || 
-			(ch >= '0' && ch <= '9' && i > 0) || 
+		if !((ch >= 'A' && ch <= 'Z') ||
+			(ch >= 'a' && ch <= 'z') ||
+			(ch >= '0' && ch <= '9' && i > 0) ||
 			ch == '_') {
 			return false
 		}
 	}
-	
-	return true
-}
 
-func MustLoad(filenames ...string) {
-	if err := Load(filenames...); err != nil {
-		panic(err)
-	}
+	return true
 }
 
 // Get is a convenience wrapper around os.Getenv for consistent API.
@@ -231,8 +444,8 @@ func GetOrDefault(key, defaultValue string) string {
 }
 
 // GetOrPanic returns the value of the environment variable named by the key.
-// It panics if the variable is not present or is empty.
-// This is useful for required configuration that the application cannot run without.
+// It panics if the variable is not present or is empty. This is useful for
+// required configuration that the application cannot run without.
 func GetOrPanic(key string) string {
 	value := os.Getenv(key)
 	if value == "" {

--- a/dotenv.go
+++ b/dotenv.go
@@ -14,7 +14,7 @@
 //
 // Basic usage:
 //
-//	import "github.com/jaavier/dotenv"
+//	import "github.com/jaavier/dotenv/v2"
 //
 //	func main() {
 //	    // Load default .env file without overriding existing env vars.

--- a/dotenv_test.go
+++ b/dotenv_test.go
@@ -11,43 +11,43 @@ func TestLoad(t *testing.T) {
 		content := `TEST_KEY=test_value
 DB_HOST=localhost
 DB_PORT=5432`
-		
+
 		tmpFile := filepath.Join(t.TempDir(), ".env")
 		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		if err := Load(tmpFile); err != nil {
 			t.Errorf("Load() error = %v", err)
 		}
-		
+
 		if got := os.Getenv("TEST_KEY"); got != "test_value" {
 			t.Errorf("TEST_KEY = %v, want %v", got, "test_value")
 		}
 	})
-	
+
 	t.Run("handles quoted values", func(t *testing.T) {
 		content := `QUOTED="value with spaces"
 SINGLE_QUOTED='single quotes'`
-		
+
 		tmpFile := filepath.Join(t.TempDir(), ".env")
 		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		if err := Load(tmpFile); err != nil {
 			t.Errorf("Load() error = %v", err)
 		}
-		
+
 		if got := os.Getenv("QUOTED"); got != "value with spaces" {
 			t.Errorf("QUOTED = %v, want %v", got, "value with spaces")
 		}
-		
+
 		if got := os.Getenv("SINGLE_QUOTED"); got != "single quotes" {
 			t.Errorf("SINGLE_QUOTED = %v, want %v", got, "single quotes")
 		}
 	})
-	
+
 	t.Run("ignores comments and empty lines", func(t *testing.T) {
 		content := `# This is a comment
 KEY1=value1
@@ -55,47 +55,47 @@ KEY1=value1
 # Another comment
 KEY2=value2
 `
-		
+
 		tmpFile := filepath.Join(t.TempDir(), ".env")
 		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		if err := Load(tmpFile); err != nil {
 			t.Errorf("Load() error = %v", err)
 		}
-		
+
 		if got := os.Getenv("KEY1"); got != "value1" {
 			t.Errorf("KEY1 = %v, want %v", got, "value1")
 		}
-		
+
 		if got := os.Getenv("KEY2"); got != "value2" {
 			t.Errorf("KEY2 = %v, want %v", got, "value2")
 		}
 	})
-	
+
 	t.Run("handles escape sequences", func(t *testing.T) {
 		content := `MULTILINE="Line1\nLine2"
 WITH_TAB="Col1\tCol2"`
-		
+
 		tmpFile := filepath.Join(t.TempDir(), ".env")
 		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		if err := Load(tmpFile); err != nil {
 			t.Errorf("Load() error = %v", err)
 		}
-		
+
 		if got := os.Getenv("MULTILINE"); got != "Line1\nLine2" {
 			t.Errorf("MULTILINE = %v, want %v", got, "Line1\nLine2")
 		}
-		
+
 		if got := os.Getenv("WITH_TAB"); got != "Col1\tCol2" {
 			t.Errorf("WITH_TAB = %v, want %v", got, "Col1\tCol2")
 		}
 	})
-	
+
 	t.Run("returns error for non-existent file with Required option", func(t *testing.T) {
 		opts := &Options{Required: true}
 		err := LoadWithOptions(opts, "/non/existent/file.env")
@@ -103,16 +103,16 @@ WITH_TAB="Col1\tCol2"`
 			t.Error("LoadWithOptions() should return error for non-existent file when Required=true")
 		}
 	})
-	
+
 	t.Run("validates key format", func(t *testing.T) {
 		content := `123INVALID=value
 VALID_KEY=value`
-		
+
 		tmpFile := filepath.Join(t.TempDir(), ".env")
 		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		err := Load(tmpFile)
 		if err == nil {
 			t.Error("Load() should return error for invalid key format")
@@ -124,32 +124,32 @@ func TestLoadWithOptions(t *testing.T) {
 	t.Run("override option", func(t *testing.T) {
 		os.Setenv("EXISTING_KEY", "original")
 		defer os.Unsetenv("EXISTING_KEY")
-		
+
 		content := `EXISTING_KEY=new_value`
 		tmpFile := filepath.Join(t.TempDir(), ".env")
 		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
-		
+
 		opts := &Options{Override: false}
 		if err := LoadWithOptions(opts, tmpFile); err != nil {
 			t.Errorf("LoadWithOptions() error = %v", err)
 		}
-		
+
 		if got := os.Getenv("EXISTING_KEY"); got != "original" {
 			t.Errorf("EXISTING_KEY should not be overridden, got %v", got)
 		}
-		
+
 		opts.Override = true
 		if err := LoadWithOptions(opts, tmpFile); err != nil {
 			t.Errorf("LoadWithOptions() error = %v", err)
 		}
-		
+
 		if got := os.Getenv("EXISTING_KEY"); got != "new_value" {
 			t.Errorf("EXISTING_KEY should be overridden, got %v", got)
 		}
 	})
-	
+
 	t.Run("required option", func(t *testing.T) {
 		opts := &Options{Required: true}
 		err := LoadWithOptions(opts, "/non/existent/file.env")
@@ -176,7 +176,7 @@ func TestParseLine(t *testing.T) {
 		{"valid underscore", "MY_KEY=value", "MY_KEY", "value", false},
 		{"number in key", "KEY123=value", "KEY123", "value", false},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotKey, gotValue, err := parseLine(tt.line)
@@ -210,7 +210,7 @@ func TestIsValidKey(t *testing.T) {
 		{"WITH.DOT", false},
 		{"WITH SPACE", false},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
 			if got := isValidKey(tt.key); got != tt.valid {
@@ -224,11 +224,11 @@ func TestGet(t *testing.T) {
 	// Set a test environment variable
 	os.Setenv("TEST_GET_VAR", "test_value")
 	defer os.Unsetenv("TEST_GET_VAR")
-	
+
 	if got := Get("TEST_GET_VAR"); got != "test_value" {
 		t.Errorf("Get() = %v, want %v", got, "test_value")
 	}
-	
+
 	if got := Get("NON_EXISTENT_VAR"); got != "" {
 		t.Errorf("Get() for non-existent var = %v, want empty string", got)
 	}
@@ -238,7 +238,7 @@ func TestGetOrDefault(t *testing.T) {
 	// Set a test environment variable
 	os.Setenv("TEST_DEFAULT_VAR", "actual_value")
 	defer os.Unsetenv("TEST_DEFAULT_VAR")
-	
+
 	tests := []struct {
 		name         string
 		key          string
@@ -249,11 +249,11 @@ func TestGetOrDefault(t *testing.T) {
 		{"non-existent var", "NON_EXISTENT_VAR", "default", "default"},
 		{"empty var", "EMPTY_VAR", "default", "default"},
 	}
-	
+
 	// Set empty var for testing
 	os.Setenv("EMPTY_VAR", "")
 	defer os.Unsetenv("EMPTY_VAR")
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetOrDefault(tt.key, tt.defaultValue); got != tt.want {
@@ -267,13 +267,13 @@ func TestGetOrPanic(t *testing.T) {
 	// Set a test environment variable
 	os.Setenv("TEST_PANIC_VAR", "safe_value")
 	defer os.Unsetenv("TEST_PANIC_VAR")
-	
+
 	t.Run("returns value for existing var", func(t *testing.T) {
 		if got := GetOrPanic("TEST_PANIC_VAR"); got != "safe_value" {
 			t.Errorf("GetOrPanic() = %v, want %v", got, "safe_value")
 		}
 	})
-	
+
 	t.Run("panics for non-existent var", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
@@ -287,11 +287,11 @@ func TestGetOrPanic(t *testing.T) {
 		}()
 		GetOrPanic("NON_EXISTENT_PANIC_VAR")
 	})
-	
+
 	t.Run("panics for empty var", func(t *testing.T) {
 		os.Setenv("EMPTY_PANIC_VAR", "")
 		defer os.Unsetenv("EMPTY_PANIC_VAR")
-		
+
 		defer func() {
 			if r := recover(); r == nil {
 				t.Error("GetOrPanic() should have panicked for empty var")

--- a/example/program.go
+++ b/example/program.go
@@ -1,3 +1,5 @@
+// Command example demonstrates how to load and read environment variables
+// with the dotenv package.
 package main
 
 import (

--- a/example/program.go
+++ b/example/program.go
@@ -3,47 +3,54 @@ package main
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/jaavier/dotenv"
 )
 
 func main() {
+	// Load the default .env file. Existing environment variables are NOT
+	// overridden — the file only fills in what is missing (12-factor safe).
 	if err := dotenv.Load(); err != nil {
 		log.Printf("Warning: .env file not found: %v\n", err)
 	}
 
-	// Using GetOrPanic for required variables
+	// Using GetOrPanic for required variables.
 	apiKey := dotenv.GetOrPanic("API_KEY")
 	fmt.Printf("API_KEY loaded: %s...\n", apiKey[:min(10, len(apiKey))])
 
-	// Using GetOrDefault for optional variables
+	// Using GetOrDefault for optional variables.
 	port := dotenv.GetOrDefault("PORT", "8080")
 	fmt.Printf("Server will run on port: %s\n", port)
 
-	// Using Get (same as os.Getenv)
-	debugMode := dotenv.Get("DEBUG")
-	if debugMode == "true" {
+	// Using Get (same as os.Getenv).
+	if dotenv.Get("DEBUG") == "true" {
 		fmt.Println("Debug mode enabled")
 	}
 
-	// Load additional config file with options
-	opts := &dotenv.Options{
-		Override: false,
-		Required: false,
+	// Parse without side effects: inspect values without touching the
+	// process environment. Great for tests and validation.
+	sample := "FEATURE_X=on\nFEATURE_Y=off # disabled for now"
+	vars, err := dotenv.Parse(strings.NewReader(sample))
+	if err != nil {
+		log.Fatalf("parse failed: %v", err)
 	}
-	if err := dotenv.LoadWithOptions(opts, "config/.env.production"); err != nil {
-		log.Printf("Note: Production config not found, using defaults\n")
+	fmt.Printf("Parsed (no env mutation): %v\n", vars)
+
+	// Overload when the file should be the source of truth (opt-in override).
+	if err := dotenv.Overload("config/.env.production"); err != nil {
+		log.Printf("Note: production config not found, using defaults\n")
 	}
 
-	// Example: Get database configuration with panic for required fields
+	// Example: build database configuration.
 	dbConfig := map[string]string{
 		"host": dotenv.GetOrPanic("DB_HOST"),
 		"port": dotenv.GetOrDefault("DB_PORT", "5432"),
 		"name": dotenv.GetOrPanic("DB_NAME"),
 		"user": dotenv.GetOrPanic("DB_USER"),
 	}
-	
-	fmt.Printf("Database configured: %s@%s:%s/%s\n", 
+
+	fmt.Printf("Database configured: %s@%s:%s/%s\n",
 		dbConfig["user"], dbConfig["host"], dbConfig["port"], dbConfig["name"])
 }
 

--- a/example/program.go
+++ b/example/program.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/jaavier/dotenv"
+	"github.com/jaavier/dotenv/v2"
 )
 
 func main() {

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jaavier/dotenv"
+	"github.com/jaavier/dotenv/v2"
 )
 
 // Load reads a .env file and populates the process environment without

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,84 @@
+package dotenv_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaavier/dotenv"
+)
+
+// Load reads a .env file and populates the process environment without
+// overriding variables that are already set.
+func ExampleLoad() {
+	dir, _ := os.MkdirTemp("", "dotenv")
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, ".env")
+	_ = os.WriteFile(path, []byte("GREETING=hello\nPORT=8080"), 0o600)
+
+	if err := dotenv.Load(path); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(os.Getenv("GREETING"))
+	fmt.Println(os.Getenv("PORT"))
+	// Output:
+	// hello
+	// 8080
+}
+
+// Parse reads key/value pairs into a map without ever touching the process
+// environment, which makes it ideal for tests and validation.
+func ExampleParse() {
+	r := strings.NewReader(`
+# comments and blank lines are ignored
+HOST=localhost
+PORT=5432           # inline comments are stripped
+LITERAL='no \n expansion here'
+ESCAPED="line1\nline2"
+`)
+	vars, err := dotenv.Parse(r)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Printf("%s:%s\n", vars["HOST"], vars["PORT"])
+	fmt.Println(vars["LITERAL"])
+	fmt.Printf("%q\n", vars["ESCAPED"])
+	// Output:
+	// localhost:5432
+	// no \n expansion here
+	// "line1\nline2"
+}
+
+// ParseBytes is a convenience wrapper for in-memory data.
+func ExampleParseBytes() {
+	vars, _ := dotenv.ParseBytes([]byte("API_KEY=secret123"))
+	fmt.Println(vars["API_KEY"])
+	// Output: secret123
+}
+
+// Overload lets values from the file override variables that already exist in
+// the environment. The default Load never overrides; Overload is the explicit
+// opt-in.
+func ExampleOverload() {
+	os.Setenv("REGION", "us-east-1")
+	defer os.Unsetenv("REGION")
+
+	dir, _ := os.MkdirTemp("", "dotenv")
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, ".env")
+	_ = os.WriteFile(path, []byte("REGION=eu-west-1"), 0o600)
+
+	_ = dotenv.Overload(path)
+	fmt.Println(os.Getenv("REGION"))
+	// Output: eu-west-1
+}
+
+// GetOrDefault returns a fallback when a variable is unset or empty.
+func ExampleGetOrDefault() {
+	os.Unsetenv("MISSING_VAR")
+	fmt.Println(dotenv.GetOrDefault("MISSING_VAR", "fallback"))
+	// Output: fallback
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/jaavier/dotenv
+module github.com/jaavier/dotenv/v2
 
 go 1.17

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,217 @@
+package dotenv
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParse_PureNoSideEffects(t *testing.T) {
+	const key = "DOTENV_PARSE_SENTINEL"
+	os.Setenv(key, "original")
+	defer os.Unsetenv(key)
+
+	vars, err := ParseBytes([]byte(key + "=fromfile\nOTHER=x"))
+	if err != nil {
+		t.Fatalf("ParseBytes() error = %v", err)
+	}
+
+	if vars[key] != "fromfile" {
+		t.Errorf("parsed %s = %q, want %q", key, vars[key], "fromfile")
+	}
+	if got := os.Getenv(key); got != "original" {
+		t.Errorf("Parse must not mutate env: %s = %q, want %q", key, got, "original")
+	}
+}
+
+func TestParse_Quoting(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		key  string
+		want string
+	}{
+		{"single quote literal", `S='a\nb'`, "S", `a\nb`},
+		{"double quote escapes", `D="a\nb"`, "D", "a\nb"},
+		{"escaped quote", `Q="he said \"hi\"\n"`, "Q", "he said \"hi\"\n"},
+		{"hash in double quotes", `H="a#b"`, "H", "a#b"},
+		{"hash in single quotes", `H='a#b'`, "H", "a#b"},
+		{"inline comment", "K=val # comment", "K", "val"},
+		{"hash not a comment", "K=pa#ss", "K", "pa#ss"},
+		{"equals in value", "K=a=b=c", "K", "a=b=c"},
+		{"empty value", "K=", "K", ""},
+		{"whitespace value", "K=    ", "K", ""},
+		{"export prefix", "export FOO=bar", "FOO", "bar"},
+		{"export with quotes", `export   BAZ="v"`, "BAZ", "v"},
+		{"tab escape", `T="c1\tc2"`, "T", "c1\tc2"},
+		{"backslash literal", `B="a\\b"`, "B", `a\b`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars, err := ParseBytes([]byte(tt.in))
+			if err != nil {
+				t.Fatalf("ParseBytes(%q) error = %v", tt.in, err)
+			}
+			if got := vars[tt.key]; got != tt.want {
+				t.Errorf("ParseBytes(%q)[%q] = %q, want %q", tt.in, tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParse_TrailingGarbageAfterQuoteRejected(t *testing.T) {
+	tests := []string{
+		`K="a"extra`,
+		`K="a"="b"`,
+		`K='a'bcd`,
+		`K="a" b`,
+	}
+	for _, in := range tests {
+		if _, err := ParseBytes([]byte(in)); !errors.Is(err, ErrInvalidFormat) {
+			t.Errorf("ParseBytes(%q) error = %v, want ErrInvalidFormat", in, err)
+		}
+	}
+}
+
+func TestParse_TrailingCommentAfterQuoteAllowed(t *testing.T) {
+	vars, err := ParseBytes([]byte(`K="a" # trailing comment`))
+	if err != nil {
+		t.Fatalf("ParseBytes() error = %v", err)
+	}
+	if vars["K"] != "a" {
+		t.Errorf("K = %q, want %q", vars["K"], "a")
+	}
+}
+
+func TestParse_DuplicateKeysLastWins(t *testing.T) {
+	vars, err := ParseBytes([]byte("K=1\nK=2\nK=3"))
+	if err != nil {
+		t.Fatalf("ParseBytes() error = %v", err)
+	}
+	if vars["K"] != "3" {
+		t.Errorf("duplicate key = %q, want %q", vars["K"], "3")
+	}
+}
+
+func TestParse_MultilineQuotedValue(t *testing.T) {
+	content := "CERT=\"line1\nline2\nline3\"\nNEXT=ok"
+	vars, err := ParseBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseBytes() error = %v", err)
+	}
+	if want := "line1\nline2\nline3"; vars["CERT"] != want {
+		t.Errorf("CERT = %q, want %q", vars["CERT"], want)
+	}
+	if vars["NEXT"] != "ok" {
+		t.Errorf("NEXT = %q, want %q", vars["NEXT"], "ok")
+	}
+}
+
+func TestParse_CRLFAndBOM(t *testing.T) {
+	content := "\xEF\xBB\xBFA=1\r\nB=2\r\n"
+	vars, err := ParseBytes([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseBytes() error = %v", err)
+	}
+	if vars["A"] != "1" || vars["B"] != "2" {
+		t.Errorf("CRLF/BOM parse = %v, want A=1 B=2", vars)
+	}
+}
+
+func TestParse_UnterminatedQuote(t *testing.T) {
+	for _, in := range []string{`K="oops`, `K='oops`} {
+		_, err := ParseBytes([]byte(in))
+		if !errors.Is(err, ErrInvalidFormat) {
+			t.Errorf("ParseBytes(%q) error = %v, want ErrInvalidFormat", in, err)
+		}
+	}
+}
+
+func TestParse_LongValueNo64KCap(t *testing.T) {
+	// bufio.Scanner would choke past 64KiB; the byte-based parser must not.
+	long := strings.Repeat("x", 200_000)
+	vars, err := ParseBytes([]byte("BIG=" + long))
+	if err != nil {
+		t.Fatalf("ParseBytes() error = %v", err)
+	}
+	if len(vars["BIG"]) != len(long) {
+		t.Errorf("BIG length = %d, want %d", len(vars["BIG"]), len(long))
+	}
+}
+
+func TestLoad_DoesNotOverrideByDefault(t *testing.T) {
+	const key = "DOTENV_NO_OVERRIDE"
+	os.Setenv(key, "real")
+	defer os.Unsetenv(key)
+
+	tmpFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(tmpFile, []byte(key+"=fromfile"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Load(tmpFile); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := os.Getenv(key); got != "real" {
+		t.Errorf("default Load must not override: %s = %q, want %q", key, got, "real")
+	}
+}
+
+func TestOverload_OverridesExisting(t *testing.T) {
+	const key = "DOTENV_OVERLOAD"
+	os.Setenv(key, "real")
+	defer os.Unsetenv(key)
+
+	tmpFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(tmpFile, []byte(key+"=fromfile"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Overload(tmpFile); err != nil {
+		t.Fatalf("Overload() error = %v", err)
+	}
+	if got := os.Getenv(key); got != "fromfile" {
+		t.Errorf("Overload must override: %s = %q, want %q", key, got, "fromfile")
+	}
+}
+
+func TestLoad_AtomicOnError(t *testing.T) {
+	const good = "DOTENV_ATOMIC_GOOD"
+	os.Unsetenv(good)
+	defer os.Unsetenv(good)
+
+	// Second line is malformed; nothing from this file should be applied.
+	content := good + "=value\n123BAD=value"
+	tmpFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(tmpFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Load(tmpFile); err == nil {
+		t.Fatal("Load() should fail on malformed file")
+	}
+	if _, ok := os.LookupEnv(good); ok {
+		t.Errorf("no variable should be applied when the file fails to parse")
+	}
+}
+
+func TestLoad_FileTooLarge(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(tmpFile, []byte("K=value123"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := LoadWithOptions(&Options{MaxFileSize: 4}, tmpFile)
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("LoadWithOptions() error = %v, want ErrFileTooLarge", err)
+	}
+}
+
+func TestLoad_MissingFileNotRequired(t *testing.T) {
+	if err := Load(filepath.Join(t.TempDir(), "does-not-exist.env")); err != nil {
+		t.Errorf("missing file with default options should be ignored, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Makes `dotenv` lighter, safer, and far more discoverable, released as a **v2** module (`github.com/jaavier/dotenv/v2`).

This PR has three parts:

### 1. Secure-by-default loader (code)
- **Breaking:** `Load` no longer overrides variables already present in the process environment (12-factor). Use the new `Overload` / `Options.Override` to opt in.
- **Atomic apply:** each file is fully parsed before any variable is set — a malformed file never leaves a half-applied environment.
- **Correct POSIX-ish quoting:** double quotes expand escapes (`\n \r \t \\ \"`), single quotes are literal, unquoted values support inline `# comments`, optional leading `export`, UTF-8 BOM and CRLF.
- **Multi-line quoted values** (e.g. PEM keys); removed the `bufio.Scanner` 64 KB line cap.
- **Hardening:** size limit enforced on bytes actually read; configurable `Options.MaxFileSize` + `ErrFileTooLarge`.
- **New API (additive, zero deps):** `Parse(io.Reader)` / `ParseBytes([]byte)` (pure, no global side effects), `Overload(...)`, `DefaultMaxFileSize`.

### 2. Discoverability (pkg.go.dev / Go Report Card / search)
- Keyword-optimized package synopsis (the sentence pkg.go.dev indexes).
- Testable Example functions (rendered on pkg.go.dev) and benchmarks (~4.6 µs/parse).
- README: 8 badges, a **"Why dotenv? (vs godotenv)"** comparison table, performance numbers, and an FAQ targeting common queries.

### 3. Quality & project health
- GitHub Actions CI: build/vet/test matrix across Go 1.17–1.23 on Linux/macOS/Windows, race + coverage (Codecov), and gofmt + golangci-lint.
- CodeQL security scanning, golangci-lint v2 config (repo is lint-clean), Dependabot.
- CHANGELOG, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, issue forms, PR template, Makefile.

## Verification
- `go build`, `go vet`, `golangci-lint run` — all clean (0 issues)
- `go test -race` passes; **coverage 90%**
- `gofmt -l .` empty; all CI YAML validated

## Breaking changes
- Import path is now `github.com/jaavier/dotenv/v2`.
- `Load` no longer overrides pre-existing environment variables (use `Overload`).

## Follow-up (manual, no API available)
After merge, to complete discoverability:
1. Tag and publish **v2.0.0** from `main` (triggers Go proxy re-indexing).
2. Set repo **topics** + **description** + **website** (values in the PR discussion / chat).
3. Submit the entry to **awesome-go** (Configuration section).

https://claude.ai/code/session_01P1nZkYKTFp9CRKDUEysphw

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1nZkYKTFp9CRKDUEysphw)_