### PR TITLE
ci: fix golangci-lint-action version (v8) and validate CI on real runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,6 @@ jobs:
           if [ -n "$unformatted" ]; then
             echo "These files are not gofmt-ed:"; echo "$unformatted"; exit 1
           fi
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.5.0


### PR DESCRIPTION
## Summary

Fixes the lint job in CI and serves to validate the full CI suite on GitHub's real runners (the workflows were just introduced).

`golangci-lint-action@v6` only supports golangci-lint **v1.x**, but the repo's `.golangci.yml` is **v2** config (validated locally with golangci-lint v2.5.0). Action **v8** supports golangci-lint >= v2.1.0, so the lint job is bumped to `@v8`.

## What this PR exercises
- `test` matrix: Go 1.17–1.23 × {ubuntu, macOS, windows}
- `race + coverage` (Codecov, tokenless)
- `lint`: gofmt check + golangci-lint v2.5.0
- CodeQL analysis

## Local verification
- `go build`, `go vet`, `golangci-lint run` (v2.5.0) — clean
- `go test -race` — pass, coverage 90%

https://claude.ai/code/session_01P1nZkYKTFp9CRKDUEysphw

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1nZkYKTFp9CRKDUEysphw)_